### PR TITLE
chore: only auto-tag when src/ changes

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -9,6 +9,8 @@ name: Auto-tag
 on:
   push:
     branches: [main]
+    paths:
+      - "src/**"
 
 jobs:
   bump-minor:


### PR DESCRIPTION
## Summary

Adds a `paths` filter to `auto-tag.yml` so releases are only cut when tool source code changes. CI config, docs, tests, and workflow updates will not trigger a release.

## Behavior

| Changed files | Release? |
|---|---|
| `src/**` | ✅ yes |
| `tests/**`, `*.md`, `.github/**` | ❌ no |

🤖 Generated with [Claude Code](https://claude.com/claude-code)