### PR TITLE
docs: add PowerShell alias for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,16 @@ uvx --from "git+https://github.com/zing3d-labs/openscad-toolkit" scad-compiler m
 
 To avoid typing the full command every time, add an alias to your shell profile:
 
+**bash / zsh** (`~/.bashrc` or `~/.zshrc`):
 ```bash
 alias scad-compiler='uvx --from "git+https://github.com/zing3d-labs/openscad-toolkit" scad-compiler'
+```
+
+**PowerShell** (`$PROFILE.CurrentUserAllHosts`):
+```powershell
+function scad-compiler {
+  uvx --from "git+https://github.com/zing3d-labs/openscad-toolkit" scad-compiler $args
+}
 ```
 
 ### Docker


### PR DESCRIPTION
Closes #9.

Extends the alias example in the Installation section to show both bash/zsh and PowerShell variants, following a confirmed working approach from @mitufy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)