### PR TITLE
ci: create git tag in workflow before build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,26 @@ on:
         required: true
 
 jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Create and push tag
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag ${{ inputs.tag }}
+          git push origin ${{ inputs.tag }}
+
   build:
     name: Build
+    needs: prepare
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -75,15 +93,3 @@ jobs:
           tags: |
             ghcr.io/zing3d-labs/openscad-toolkit:${{ steps.version.outputs.version }}
             ghcr.io/zing3d-labs/openscad-toolkit:latest
-
-  update-action-tag:
-    name: Update v1 tag
-    needs: github-release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - run: |
-          git tag -f v1
-          git push origin v1 --force


### PR DESCRIPTION
## Summary
- Adds a `prepare` job that runs before `build`. When triggered via `workflow_dispatch`, it creates and pushes the tag so that `setuptools-scm` can find it during the build step. The step is a no-op on tag-push triggers (tag already exists).
- Removes the leftover `update-action-tag` job (was pushing a floating `v1` tag, not needed).

## Root cause of 0.0.0
`workflow_dispatch` passes the tag name as an input, but the tag didn't exist in git. `setuptools-scm` couldn't find a matching tag and fell back to `0.0.0`. The build job now depends on `prepare`, which guarantees the tag is in git before the checkout happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)