### PR TITLE
fix: rewrite section headers to [Hidden] in use'd files

### DIFF
--- a/src/scadtools/compiler.py
+++ b/src/scadtools/compiler.py
@@ -422,6 +422,8 @@ def process_scad_file(
             if INCLUDE_RE.match(line):
                 # Emit variables accumulated in this segment, then inline the include
                 seg_items, new_vars = extract_top_level_items(seg, defined_variables)
+                if not is_entry_file:
+                    seg_items = [SECTION_HEADER_RE.sub("/* [Hidden] */", ln) for ln in seg_items]
                 defined_variables.update(new_vars)
                 output_content.extend(seg_items)
                 seg = []
@@ -431,6 +433,8 @@ def process_scad_file(
 
         # Emit variables from the final segment (after the last include)
         seg_items, new_vars = extract_top_level_items(seg, defined_variables)
+        if not is_entry_file:
+            seg_items = [SECTION_HEADER_RE.sub("/* [Hidden] */", ln) for ln in seg_items]
         defined_variables.update(new_vars)
         output_content.extend(seg_items)
         if seg_items:

--- a/tests/fixtures/entry_with_use_sections.scad
+++ b/tests/fixtures/entry_with_use_sections.scad
@@ -1,0 +1,8 @@
+use <used_with_sections.scad>
+
+/* [My Settings] */
+
+// Size
+size = 20;
+
+used_module_with_sections(size, size);

--- a/tests/fixtures/used_with_sections.scad
+++ b/tests/fixtures/used_with_sections.scad
@@ -1,0 +1,13 @@
+/* [Required Dimensions] */
+
+// Width
+width = 10;
+
+/* [Advanced Options] */
+
+// Depth
+depth = 5;
+
+module used_module_with_sections(w, d) {
+    cube([w, d, 1]);
+}

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -675,3 +675,18 @@ def test_compile_existing_hidden_section_not_duplicated():
     result = compile_scad(str(FIXTURES / "customizer.scad"))
     # customizer.scad is the entry file — its own [Hidden] section is preserved
     assert "/* [Hidden] */" in result
+
+
+def test_compile_used_section_headers_become_hidden():
+    """Section headers from use'd files must be rewritten to /* [Hidden] */
+    so they don't create empty sections in the MakerWorld/OpenSCAD customizer.
+
+    Regression test: the only_modules_functions path in process_scad_file was not
+    applying SECTION_HEADER_RE substitution to seg_items from extract_top_level_items.
+    """
+    result = compile_scad(str(FIXTURES / "entry_with_use_sections.scad"))
+    # Section headers from used_with_sections.scad must be hidden
+    assert "/* [Required Dimensions] */" not in result
+    assert "/* [Advanced Options] */" not in result
+    # Entry file's own section header must be preserved
+    assert "/* [My Settings] */" in result


### PR DESCRIPTION
## Summary

- Section headers (e.g. `/* [Required Dimensions] */`) from `use`'d files were passing through to the compiled output unrewritten, creating empty sections in the OpenSCAD Customizer
- The `only_modules_functions` path in `process_scad_file` was missing the `SECTION_HEADER_RE` substitution that the full inlining (`include`) path already applies
- Fix: apply `SECTION_HEADER_RE.sub("/* [Hidden] */", ...)` to `seg_items` whenever `not is_entry_file` in both segment-emit locations

## Test plan

- [x] Added `tests/fixtures/used_with_sections.scad` — a `use`'d file with `/* [Required Dimensions] */` and `/* [Advanced Options] */` section headers
- [x] Added `tests/fixtures/entry_with_use_sections.scad` — entry file that `use`s it, with its own `/* [My Settings] */`
- [x] Added `test_compile_used_section_headers_become_hidden` — confirmed it failed before the fix and passes after
- [x] All 74 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)