### PR TITLE
Pin openscad_parser below 2.0 to avoid silent AST truncation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,11 @@ description = "OpenSCAD compiler and build tools"
 readme = "README.md"
 license = "CC-BY-NC-SA-4.0"
 requires-python = ">=3.11"
-dependencies = ["openscad_parser>=1.0.0"]
+# openscad_parser 2.x's grammar silently truncates AST output partway through
+# files containing a bare top-level { } scoping block, dropping any module/
+# function definitions that follow -- pinned below 2.0 until that's fixed
+# upstream (belfryscad/openscad_parser).
+dependencies = ["openscad_parser>=1.0.0,<2.0.0"]
 authors = [
     { name = "Jonathan Huizingh" }
 ]

--- a/tests/fixtures/used_module_in_block.scad
+++ b/tests/fixtures/used_module_in_block.scad
@@ -1,0 +1,15 @@
+// A module file that wraps its demo call and module definition in a bare
+// { } block, matching a real-world pattern used to hide helper variables
+// from the Customizer while a standalone demo call still renders when this
+// file is opened directly (not `use`'d).
+someVar = 42;
+
+{
+  helperSize = someVar * 2;
+
+  usedHelper(helperSize);
+
+  module usedHelper(size) {
+    sphere(r=size);
+  }
+}

--- a/tests/fixtures/with_use_block_wrapped_module.scad
+++ b/tests/fixtures/with_use_block_wrapped_module.scad
@@ -1,0 +1,5 @@
+use <used_module_in_block.scad>
+
+Size = 5;
+
+usedHelper(Size);

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -389,6 +389,15 @@ def test_compile_use_inlines_module():
     assert "usedHelper(Size)" in result
 
 
+def test_compile_use_inlines_module_nested_in_bare_block():
+    """A module def wrapped in a bare { } block (used to hide a helper
+    variable from the Customizer) must still be found and inlined when the
+    containing file is `use`'d, not just when it's the entry file."""
+    result = compile_scad(str(FIXTURES / "with_use_block_wrapped_module.scad"))
+    assert "module usedHelper" in result
+    assert "usedHelper(Size)" in result
+
+
 def test_compile_include_inlines_all():
     result = compile_scad(str(FIXTURES / "with_include.scad"))
     assert "includedVar = 100" in result


### PR DESCRIPTION
## Summary

`openscad_parser` 2.x's grammar silently stops emitting AST nodes partway
through a file once it hits a bare top-level `{ }` scoping block, dropping
any module/function definitions that follow. Since our dependency
constraint was unpinned (`openscad_parser>=1.0.0`), any package consuming
this repo by git tag can still resolve a newer, broken parser release at
install time — the tag itself never changes, but `uvx`/`pip` re-resolve
the floating constraint fresh on every invocation, with no lock file to
catch drift.

Concretely: v0.14.0 was tagged 2026-03-11, when `openscad_parser==1.0.1`
was the newest release satisfying `>=1.0.0` — CI genuinely passed against
that version. `openscad_parser 2.1.0` (first broken major release) wasn't
published until 2026-03-22, 11 days later. By the time this project
actually used `uvx --from git+...@v0.14.0` in production, PyPI had moved
to `2.6.1`, which is silently broken for this case.

Real-world impact: `models/opengrid/parts/opengrid_beam.scad` (in
zing3d-labs/openscad-models) wraps its `module opengrid_beam(...)`
definition in exactly such a bare `{ }` block (an intentional pattern to
hide a helper variable from the OpenSCAD Customizer). Any file that
`use`s it — e.g. `grid_basket.scad` — silently lost all beam geometry
when compiled through this toolkit, with only an easily-missed
`WARNING: Ignoring unknown module 'opengrid_beam'` from OpenSCAD itself
(not from this compiler) as a clue.

## Changes

- `pyproject.toml`: pin `openscad_parser>=1.0.0,<2.0.0`, with a comment
  explaining why.
- `tests/fixtures/used_module_in_block.scad` +
  `tests/fixtures/with_use_block_wrapped_module.scad`: regression
  fixtures reproducing the exact pattern (a `use`'d file with a module
  definition nested inside a bare scoping block).
- `tests/test_compiler.py`: new
  `test_compile_use_inlines_module_nested_in_bare_block`, confirmed to
  fail against `openscad_parser==2.6.1` and pass with the pin in place.

## Test plan

- [x] Full suite passes locally against the pinned dependency (74/74)
- [x] New regression test confirmed to fail before the fix, pass after
- [x] Verified end-to-end against the real `grid_basket.scad`: compiles
      cleanly, `opengrid_beam` module present, zero "unknown module"
      warnings on STL export

## Follow-up (not included here)

Recommend adopting a checked-in `uv.lock` plus `uv sync --locked` in CI
so a passing CI run stays a durable, replayable guarantee instead of a
snapshot that can silently stop reflecting reality as PyPI moves forward.